### PR TITLE
feature export ONNX and bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,166 @@
+# weight
+*.pth
+*.onnx
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/eipl/tutorials/airec/sarnn/bin/test.py
+++ b/eipl/tutorials/airec/sarnn/bin/test.py
@@ -119,7 +119,7 @@ ect_pts = np.array(ect_pts_list)
 dec_pts = np.array(dec_pts_list)
 ect_pts = ect_pts.reshape(-1, params["k_dim"], 2) * img_size
 dec_pts = dec_pts.reshape(-1, params["k_dim"], 2) * img_size
-enc_pts = np.clip(ect_pts, 0, img_size)
+ect_pts = np.clip(ect_pts, 0, img_size)
 dec_pts = np.clip(dec_pts, 0, img_size)
 
 

--- a/eipl/tutorials/airec/sarnn/bin/test.py
+++ b/eipl/tutorials/airec/sarnn/bin/test.py
@@ -73,7 +73,7 @@ model.eval()
 # Inference
 img_size = 128
 image_list, joint_list = [], []
-ect_pts_list, dec_pts_list = [], []
+enc_pts_list, dec_pts_list = [], []
 state = None
 nloop = len(images)
 for loop_ct in range(nloop):
@@ -90,7 +90,7 @@ for loop_ct in range(nloop):
         joint_t = args.input_param * joint_t + (1.0 - args.input_param) * y_joint
 
     # predict rnn
-    y_image, y_joint, ect_pts, dec_pts, state = model(img_t, joint_t, state)
+    y_image, y_joint, enc_pts, dec_pts, state = model(img_t, joint_t, state)
 
     # denormalization
     pred_image = tensor2numpy(y_image[0])
@@ -106,7 +106,7 @@ for loop_ct in range(nloop):
     # append data
     image_list.append(pred_image)
     joint_list.append(pred_joint)
-    ect_pts_list.append(tensor2numpy(ect_pts[0]))
+    enc_pts_list.append(tensor2numpy(enc_pts[0]))
     dec_pts_list.append(tensor2numpy(dec_pts[0]))
 
     print("loop_ct:{}, joint:{}".format(loop_ct, pred_joint))
@@ -115,11 +115,11 @@ pred_image = np.array(image_list)
 pred_joint = np.array(joint_list)
 
 # split key points
-ect_pts = np.array(ect_pts_list)
+enc_pts = np.array(enc_pts_list)
 dec_pts = np.array(dec_pts_list)
-ect_pts = ect_pts.reshape(-1, params["k_dim"], 2) * img_size
+enc_pts = enc_pts.reshape(-1, params["k_dim"], 2) * img_size
 dec_pts = dec_pts.reshape(-1, params["k_dim"], 2) * img_size
-ect_pts = np.clip(ect_pts, 0, img_size)
+enc_pts = np.clip(enc_pts, 0, img_size)
 dec_pts = np.clip(dec_pts, 0, img_size)
 
 
@@ -135,7 +135,7 @@ def anim_update(i):
     # plot camera image
     ax[0].imshow(images[i, :, :, ::-1])
     for j in range(params["k_dim"]):
-        ax[0].plot(ect_pts[i, j, 0], ect_pts[i, j, 1], "bo", markersize=6)  # encoder
+        ax[0].plot(enc_pts[i, j, 0], enc_pts[i, j, 1], "bo", markersize=6)  # encoder
         ax[0].plot(
             dec_pts[i, j, 0], dec_pts[i, j, 1], "rx", markersize=6, markeredgewidth=2
         )  # decoder

--- a/eipl/tutorials/open_manipulator/sarnn/bin/export_onnx.py
+++ b/eipl/tutorials/open_manipulator/sarnn/bin/export_onnx.py
@@ -1,0 +1,67 @@
+import argparse
+import json
+from os import path
+
+import torch
+
+from eipl.model import SARNN
+
+def load_config(file):
+    with open(file, "r") as f:
+        config = json.load(f)
+
+    #! temp fix
+    # joint_dim is 5 for open_manipulator
+    # im_size is 64x64 for object grasp task
+    # hard coded for now
+    config["joint_dim"] = 5
+    config["im_size"] = [64, 64]
+
+    return config
+
+
+def export_onnx(weight, output, config, verbose=False):
+    model = SARNN(
+        rec_dim=config["rec_dim"],
+        joint_dim=config["joint_dim"],
+        k_dim=config["k_dim"],
+        heatmap_size=config["heatmap_size"],
+        temperature=config["temperature"],
+        im_size=config["im_size"],
+    )
+
+    ckpt = torch.load(weight, map_location=torch.device("cpu"))
+    model.load_state_dict(ckpt["model_state_dict"])
+    model.eval()
+
+    input_names = ["i.image", "i.joint", "i.state_h", "i.state_c"]
+    output_names = ["o.image", "o.joint", "o.enc_pts", "o.dec_pts", "o.state_h", "o.state_c"]
+    dummy_input = (
+        torch.randn(1, 3, config["im_size"][0], config["im_size"][1]),
+        torch.randn(1, config["joint_dim"]),
+        tuple(torch.randn(1, config["rec_dim"]) for _ in range(2)),
+    )
+    torch.onnx.export(
+        model,
+        dummy_input,
+        output,
+        input_names=input_names,
+        output_names=output_names,
+        verbose=verbose,
+    )
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("weight", help="PyTorch model weight file")
+    parser.add_argument("--config", help="Configuration file", default=None)
+    parser.add_argument("--output", help="Output ONNX file", default="model.onnx")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args()
+
+    if args.config is not None:
+        config = load_config(args.config)
+    else:
+        config_path = path.join(path.dirname(args.weight), "args.json")
+        config = load_config(config_path)
+
+    export_onnx(args.weight, args.output, config, args.verbose)

--- a/eipl/tutorials/open_manipulator/sarnn/bin/test.py
+++ b/eipl/tutorials/open_manipulator/sarnn/bin/test.py
@@ -4,8 +4,6 @@
 #
 
 import os
-import glob
-import sys
 import torch
 import argparse
 import numpy as np
@@ -74,7 +72,7 @@ model.eval()
 # Inference
 img_size = 64
 image_list, joint_list = [], []
-ect_pts_list, dec_pts_list = [], []
+enc_pts_list, dec_pts_list = [], []
 state = None
 nloop = len(images)
 for loop_ct in range(nloop):
@@ -86,7 +84,7 @@ for loop_ct in range(nloop):
     joint_t = normalization(joint_t, joint_bounds, minmax)
 
     # predict rnn
-    y_image, y_joint, ect_pts, dec_pts, state = model(img_t, joint_t, state)
+    y_image, y_joint, enc_pts, dec_pts, state = model(img_t, joint_t, state)
 
     # denormalization
     pred_image = tensor2numpy(y_image[0])
@@ -98,7 +96,7 @@ for loop_ct in range(nloop):
     # append data
     image_list.append(pred_image)
     joint_list.append(pred_joint)
-    ect_pts_list.append(tensor2numpy(ect_pts[0]))
+    enc_pts_list.append(tensor2numpy(enc_pts[0]))
     dec_pts_list.append(tensor2numpy(dec_pts[0]))
 
     print("loop_ct:{}, joint:{}".format(loop_ct, pred_joint))
@@ -107,11 +105,11 @@ pred_image = np.array(image_list)
 pred_joint = np.array(joint_list)
 
 # split key points
-ect_pts = np.array(ect_pts_list)
+enc_pts = np.array(enc_pts_list)
 dec_pts = np.array(dec_pts_list)
-ect_pts = ect_pts.reshape(-1, params["k_dim"], 2) * img_size
+enc_pts = enc_pts.reshape(-1, params["k_dim"], 2) * img_size
 dec_pts = dec_pts.reshape(-1, params["k_dim"], 2) * img_size
-ect_pts = np.clip(ect_pts, 0, img_size)
+enc_pts = np.clip(enc_pts, 0, img_size)
 dec_pts = np.clip(dec_pts, 0, img_size)
 
 
@@ -127,7 +125,7 @@ def anim_update(i):
     # plot camera image
     ax[0].imshow(images[i, :, :, ::-1])
     for j in range(params["k_dim"]):
-        ax[0].plot(ect_pts[i, j, 0], ect_pts[i, j, 1], "bo", markersize=6)  # encoder
+        ax[0].plot(enc_pts[i, j, 0], enc_pts[i, j, 1], "bo", markersize=6)  # encoder
         ax[0].plot(
             dec_pts[i, j, 0], dec_pts[i, j, 1], "rx", markersize=6, markeredgewidth=2
         )  # decoder

--- a/eipl/tutorials/open_manipulator/sarnn/bin/test.py
+++ b/eipl/tutorials/open_manipulator/sarnn/bin/test.py
@@ -111,7 +111,7 @@ ect_pts = np.array(ect_pts_list)
 dec_pts = np.array(dec_pts_list)
 ect_pts = ect_pts.reshape(-1, params["k_dim"], 2) * img_size
 dec_pts = dec_pts.reshape(-1, params["k_dim"], 2) * img_size
-enc_pts = np.clip(ect_pts, 0, img_size)
+ect_pts = np.clip(ect_pts, 0, img_size)
 dec_pts = np.clip(dec_pts, 0, img_size)
 
 

--- a/eipl/tutorials/robosuite/sarnn/bin/test.py
+++ b/eipl/tutorials/robosuite/sarnn/bin/test.py
@@ -3,14 +3,16 @@
 # Released under the MIT License.
 #
 
-import os
-import torch
 import argparse
-import numpy as np
-import matplotlib.pylab as plt
+import os
+
 import matplotlib.animation as anim
-from eipl.utils import restore_args, tensor2numpy, deprocess_img, normalization
+import matplotlib.pylab as plt
+import numpy as np
+import torch
+
 from eipl.model import SARNN
+from eipl.utils import deprocess_img, normalization, restore_args, tensor2numpy
 
 # argument parser
 parser = argparse.ArgumentParser()
@@ -89,7 +91,7 @@ ect_pts = np.array(ect_pts_list)
 dec_pts = np.array(dec_pts_list)
 ect_pts = ect_pts.reshape(-1, params["k_dim"], 2) * im_size
 dec_pts = dec_pts.reshape(-1, params["k_dim"], 2) * im_size
-enc_pts = np.clip(ect_pts, 0, im_size)
+ect_pts = np.clip(ect_pts, 0, im_size)
 dec_pts = np.clip(dec_pts, 0, im_size)
 
 

--- a/eipl/tutorials/robosuite/sarnn/bin/test.py
+++ b/eipl/tutorials/robosuite/sarnn/bin/test.py
@@ -54,7 +54,7 @@ model.eval()
 # Inference
 im_size = 64
 image_list, joint_list = [], []
-ect_pts_list, dec_pts_list = [], []
+enc_pts_list, dec_pts_list = [], []
 state = None
 nloop = len(images)
 for loop_ct in range(nloop):
@@ -66,7 +66,7 @@ for loop_ct in range(nloop):
     joint_t = torch.Tensor(np.expand_dims(joint_t, 0))
 
     # predict rnn
-    y_image, y_joint, ect_pts, dec_pts, state = model(img_t, joint_t, state)
+    y_image, y_joint, enc_pts, dec_pts, state = model(img_t, joint_t, state)
 
     # denormalization
     pred_image = tensor2numpy(y_image[0])
@@ -78,7 +78,7 @@ for loop_ct in range(nloop):
     # append data
     image_list.append(pred_image)
     joint_list.append(pred_joint)
-    ect_pts_list.append(tensor2numpy(ect_pts[0]))
+    enc_pts_list.append(tensor2numpy(enc_pts[0]))
     dec_pts_list.append(tensor2numpy(dec_pts[0]))
 
     print("loop_ct:{}, joint:{}".format(loop_ct, pred_joint))
@@ -87,11 +87,11 @@ pred_image = np.array(image_list)
 pred_joint = np.array(joint_list)
 
 # split key points
-ect_pts = np.array(ect_pts_list)
+enc_pts = np.array(enc_pts_list)
 dec_pts = np.array(dec_pts_list)
-ect_pts = ect_pts.reshape(-1, params["k_dim"], 2) * im_size
+enc_pts = enc_pts.reshape(-1, params["k_dim"], 2) * im_size
 dec_pts = dec_pts.reshape(-1, params["k_dim"], 2) * im_size
-ect_pts = np.clip(ect_pts, 0, im_size)
+enc_pts = np.clip(enc_pts, 0, im_size)
 dec_pts = np.clip(dec_pts, 0, im_size)
 
 
@@ -107,7 +107,7 @@ def anim_update(i):
     # plot camera image
     ax[0].imshow(images[i])
     for j in range(params["k_dim"]):
-        ax[0].plot(ect_pts[i, j, 0], ect_pts[i, j, 1], "co", markersize=12)  # encoder
+        ax[0].plot(enc_pts[i, j, 0], enc_pts[i, j, 1], "co", markersize=12)  # encoder
         ax[0].plot(
             dec_pts[i, j, 0], dec_pts[i, j, 1], "rx", markersize=12, markeredgewidth=2
         )  # decoder

--- a/eipl/utils/callback.py
+++ b/eipl/utils/callback.py
@@ -21,7 +21,7 @@ class EarlyStopping:
         self.best_score = None
         self.save_ckpt = False
         self.stop_flag = False
-        self.val_loss_min = np.Inf
+        self.val_loss_min = np.inf
 
     def __call__(self, val_loss):
         if np.isnan(val_loss) or np.isinf(val_loss):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ tqdm
 scikit-learn
 torch
 torchvision
-torchaudio
+onnx


### PR DESCRIPTION
## Feature
- feature export onnx function for open manipulator
- add gitignore

## Bugfix
- replace `np.Inf` with `np.inf`
  - `np.Inf` is deprecated from Numpy 2.
- fix variable name in test file

## How to check

```sh
cd eipl/tutorials/open_manipulator/sarnn/
python bin/export_onnx.py <path/to/SARNN.pth> --output model.onnx
```
